### PR TITLE
Remove and 301 redirect trailing slashes in URLs

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -32,6 +32,8 @@ require 'rack/rewrite'
 use Rack::Rewrite do
   # Articles -> Editorial
   r301 %r{^/articles(?!\.xml)(.*)$}, '/editorial$1'
+  # Remove and 301 redirect trailing slashes in URLs
+  r301 %r{^/(.*)/$}, '/$1'
 end
 
 run Middleman.server


### PR DESCRIPTION
This adds a rack rewrite to 301 redirect URLs with trailing slashes to their non-trailing slash counterpart.

cc/ @jlong
