### PR TITLE
Allow scrolling on pre elements

### DIFF
--- a/source/stylesheets/partials/_typography.scss
+++ b/source/stylesheets/partials/_typography.scss
@@ -3,7 +3,7 @@
 %link {
   color: $link-color;
   text-decoration: underline;
-  
+
   &:visited { color: $link-visited-color; }
   &:hover, &:visited:hover { color: $link-hover-color; text-decoration: none; }
 
@@ -121,7 +121,7 @@ a.top-link {
     margin: 2em 0;
     padding: 2.5em;
     background: #f0f2f4;
-    overflow: hidden;
+    overflow: auto;
   }
 
   sup, sub {


### PR DESCRIPTION
Currently on smaller viewports, when code examples overflow the `pre` element, it gets cut-off to the right with no ability to scroll and see it. This simply adds scrolling on the x-axis so that you can see all of the code.
